### PR TITLE
Add color to theme and fix sdk lower than 24  problem

### DIFF
--- a/app/src/main/java/com/snakyapps/khiardle/backend/repository/LocalStorageLevelRepository.kt
+++ b/app/src/main/java/com/snakyapps/khiardle/backend/repository/LocalStorageLevelRepository.kt
@@ -2,7 +2,6 @@ package com.snakyapps.khiardle.backend.repository
 
 import android.content.SharedPreferences
 import com.snakyapps.khiardle.backend.models.Level
-import java.lang.Long.max
 
 class LocalStorageLevelRepository(
     private val sharedPreferences: SharedPreferences,
@@ -12,7 +11,7 @@ class LocalStorageLevelRepository(
             return sharedPreferences.getLong("LastLevel", 1)
         }
         set(value) {
-            sharedPreferences.edit().putLong("LastLevel", value).commit()
+            sharedPreferences.edit().putLong("LastLevel", value).apply()
         }
 
     override fun getCurrentLevelNumber(): Long {
@@ -20,7 +19,7 @@ class LocalStorageLevelRepository(
     }
 
     override fun levelPassed(level: Level) {
-        val settingLevel = max(level.number + 1, lastLevel)
+        val settingLevel = kotlin.math.max(level.number + 1, lastLevel)
         lastLevel = settingLevel
     }
 }

--- a/app/src/main/java/com/snakyapps/khiardle/ui/Keyboard.kt
+++ b/app/src/main/java/com/snakyapps/khiardle/ui/Keyboard.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -33,11 +34,7 @@ import androidx.compose.ui.unit.sp
 import com.snakyapps.khiardle.backend.models.EqualityStatus
 import com.snakyapps.khiardle.backend.models.KeyboardKeys
 import com.snakyapps.khiardle.backend.viewmodel.GameViewModel
-import com.snakyapps.khiardle.ui.theme.correctBackground
-import com.snakyapps.khiardle.ui.theme.keyboard
-import com.snakyapps.khiardle.ui.theme.keyboardDisabled
-import com.snakyapps.khiardle.ui.theme.onKeyboard
-import com.snakyapps.khiardle.ui.theme.wrongPositionBackground
+import com.snakyapps.khiardle.ui.theme.*
 
 @Composable
 internal fun GameKeyboard(
@@ -85,11 +82,12 @@ internal fun GameKeyboard(
                 .height(40.dp)
                 .clip(RoundedCornerShape(2.dp))
                 .background(MaterialTheme.colorScheme.primary)
+                .padding(4.dp)
                 .clickable(onClick = onSubmit), Alignment.Center) {
                 Text(text = "CHECK",
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Black,
-
+                    color = MaterialTheme.colorScheme.onSubmit,
                     modifier = Modifier
                         .padding(horizontal = 4.dp)
                         .clip(RoundedCornerShape(4.dp)))

--- a/app/src/main/java/com/snakyapps/khiardle/ui/Keyboard.kt
+++ b/app/src/main/java/com/snakyapps/khiardle/ui/Keyboard.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp

--- a/app/src/main/java/com/snakyapps/khiardle/ui/theme/Theme.kt
+++ b/app/src/main/java/com/snakyapps/khiardle/ui/theme/Theme.kt
@@ -50,6 +50,7 @@ val ColorScheme.enteringBackground @Composable get() = MaterialTheme.colorScheme
 val ColorScheme.keyboard @Composable get() = Color(0xFF393939)
 val ColorScheme.keyboardDisabled @Composable get() = Color(0xFF642424)
 val ColorScheme.onKeyboard @Composable get() = Color(0xFFE7E7E7)
+val ColorScheme.onSubmit @Composable get() = Color(0xFFF7F7F7)
 
 @Composable
 fun KhiardleTheme(


### PR DESCRIPTION
Hi,
I was checking your project when I found out you use java.lang.Long.max this function.

In android sdk lower than 24 we can't use it so I change this function.

Also I change commit to apply for setting value to shared Preferences.

And I add text color for submit button.